### PR TITLE
fix: remove bold styling from +NEW CHAT button

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -524,7 +524,7 @@ header h1 {
     border: none;
     color: var(--text-secondary);
     font-size: 0.875rem;
-    font-weight: 600;
+    font-weight: 400;
     cursor: pointer;
     transition: color 0.2s ease;
     text-align: left;


### PR DESCRIPTION
Changed font-weight from 600 to 400 to give the button normal weight styling.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)